### PR TITLE
Correctly copyable characters in pdf

### DIFF
--- a/examples/roma-demo-en.tex
+++ b/examples/roma-demo-en.tex
@@ -6,7 +6,8 @@
 \documentclass[english]{beamer}
 \usepackage[english]{babel}
 \usepackage[utf8]{inputenx}
-
+\usepackage[T1]{fontenc}      % Font encoding
+\usepackage{lmodern}          % lmodern font, correctly copyable characters in pdf
 
 \usetheme[
   bullet=circle,                  % Use circles instead of squares for bullets

--- a/examples/roma-demo-it.tex
+++ b/examples/roma-demo-it.tex
@@ -5,7 +5,8 @@
 \documentclass[italian]{beamer}
 \usepackage[italian]{babel}
 \usepackage[utf8]{inputenx}
-
+\usepackage[T1]{fontenc}      % Font encoding
+\usepackage{lmodern}          % lmodern font, correctly copyable characters in pdf
 
 \usetheme[
   bullet=circle,                  % Use circles instead of squares for bullets


### PR DESCRIPTION
Added two packages for fix the font issue when trying to copy a string from the pdf file.